### PR TITLE
Enable CS "active-high" device support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,5 +30,5 @@ repos:
         name: pylint (examples code)
         description: Run pylint rules on "examples/*.py" files
         entry: /usr/bin/env bash -c
-        args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name $example; done)']
+        args: ['([[ ! -d "examples" ]] || for example in $(find . -path "./examples/*.py"); do pylint --disable=missing-docstring,invalid-name,consider-using-f-string $example; done)']
         language: system

--- a/adafruit_bus_device/spi_device.py
+++ b/adafruit_bus_device/spi_device.py
@@ -21,6 +21,8 @@ class SPIDevice:
     :param ~busio.SPI spi: The SPI bus the device is on
     :param ~digitalio.DigitalInOut chip_select: The chip select pin object that implements the
         DigitalInOut API.
+    :param bool cs_active_value: Set to true if your device requires CS to be active high.
+        Defaults to false.
     :param int extra_clocks: The minimum number of clock cycles to cycle the bus after CS is high.
         (Used for SD cards.)
 
@@ -55,6 +57,7 @@ class SPIDevice:
         spi,
         chip_select=None,
         *,
+        cs_active_value=False,
         baudrate=100000,
         polarity=0,
         phase=0,
@@ -66,6 +69,7 @@ class SPIDevice:
         self.phase = phase
         self.extra_clocks = extra_clocks
         self.chip_select = chip_select
+        self.cs_active_value = cs_active_value
         if self.chip_select:
             self.chip_select.switch_to_output(value=True)
 
@@ -76,12 +80,12 @@ class SPIDevice:
             baudrate=self.baudrate, polarity=self.polarity, phase=self.phase
         )
         if self.chip_select:
-            self.chip_select.value = False
+            self.chip_select.value = self.cs_active_value
         return self.spi
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.chip_select:
-            self.chip_select.value = True
+            self.chip_select.value = not self.cs_active_value
         if self.extra_clocks > 0:
             buf = bytearray(1)
             buf[0] = 0xFF


### PR DESCRIPTION
Reference https://github.com/adafruit/Adafruit_CircuitPython_BusDevice/issues/71

Enables SPIDevice to be used for things like the Sitronix ST7920 LCD display which requires CS to be pulled high during commands or data transfers.

<img width="709" alt="ST7920 LCD Display timing diagram" src="https://user-images.githubusercontent.com/546179/134233359-7a09a8ee-4c4a-4b35-8eec-29cfa0780c0a.png">